### PR TITLE
Idempotent decode and encode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -107,11 +107,13 @@ function encodeTorrentFile (parsed) {
     info: parsed.info
   }
 
-  torrent['announce-list'] = (parsed.announce || []).map(function (url) {
-    if (!torrent.announce) torrent.announce = url
-    url = new Buffer(url, 'utf8')
-    return [ url ]
-  })
+  if (parsed.announce.length > 0) {
+    torrent['announce-list'] = (parsed.announce || []).map(function (url) {
+      if (!torrent.announce) torrent.announce = url
+      url = new Buffer(url, 'utf8')
+      return [ url ]
+    })
+  }
 
   torrent['url-list'] = parsed.urlList || []
 

--- a/test/encode.js
+++ b/test/encode.js
@@ -4,9 +4,12 @@ var test = require('tape')
 
 test('encode', function (t) {
   var parsedTorrent = parseTorrentFile(fixtures.leaves.torrent)
+
   var buf = parseTorrentFile.encode(parsedTorrent)
   var doubleParsedTorrent = parseTorrentFile(buf)
 
+  console.log(buf.length, fixtures.leaves.torrent.length)
+  t.deepEqual(buf, fixtures.leaves.torrent)
   t.deepEqual(doubleParsedTorrent, parsedTorrent)
   t.end()
 })


### PR DESCRIPTION
Hi @feross!

I'm trying to make the encode and decoding of torrent files idempotent. It makes it extremely useful when linking to torrent files by CID/multihash, so that at least we don't generate new torrent file versions in memory while manipulating them.

Right now, I'm 5 bytes down from the original:

```sh
# encode
634 639
not ok 9 should be equivalent
  ---
    operator: deepEqual
    expected: |-
      <Buffer 64 31 30 3a 63 72 65 61 74 65 64 20 62 79 31 33 3a 75 54 6f 72 72 65 6e 74 2f 33 33 30 30 31 33 3a 63 72 65 61 74 69 6f 6e 20 64 61 74 65 69 31 33 37 ... >
    actual: |-
      <Buffer 64 31 30 3a 63 72 65 61 74 65 64 20 62 79 31 33 3a 75 54 6f 72 72 65 6e 74 2f 33 33 30 30 31 33 3a 63 72 65 61 74 69 6f 6e 20 64 61 74 65 69 31 33 37 ... >
    at: Test.<anonymous> (/Users/koruza/code/parse-torrent-file/test/encode.js:12:5)
  ...
```

Could you help me figure out these last 5 bytes?

I understand that there is no requirement for this by the bittorrent spec and it might even be impossible to ensure that is always idempotent. If this turns out to be the case, I'll just have to cope with it :)

Thank you!