### PR TITLE
Fixed issue when announce-list is not an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function decodeTorrentFile (torrent) {
 
   // announce and announce-list will be missing if metadata fetched via ut_metadata
   result.announce = []
-  if (torrent['announce-list'] && torrent['announce-list'].forEach) {
+  if (torrent['announce-list'] && torrent['announce-list'].length && torrent['announce-list'].forEach) {
     torrent['announce-list'].forEach(function (urls) {
       urls.forEach(function (url) {
         result.announce.push(url.toString())

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function decodeTorrentFile (torrent) {
 
   // announce and announce-list will be missing if metadata fetched via ut_metadata
   result.announce = []
-  if (torrent['announce-list'] && torrent['announce-list'].length) {
+  if (torrent['announce-list'] && torrent['announce-list'].forEach) {
     torrent['announce-list'].forEach(function (urls) {
       urls.forEach(function (url) {
         result.announce.push(url.toString())


### PR DESCRIPTION
In some rare cases, announce-list is a binary buffer, not an array. So, it passes the condition checking for .length property but causes to exception because it has no forEach method.